### PR TITLE
Added link to Esri Cedar wrapper for Vega

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,8 @@
             type-checking to ensure your specifications are correct, and offers convenience methods that turn Python data structures into Vega specifications.</p>
 
             <p>The MediaWiki <a href="https://www.mediawiki.org/wiki/Extension:Graph/Demo">Graph extension</a> allows you to embed Vega visualizations on MediaWiki sites, including Wikipedia.</p>
+
+            <p><a href="http://esri.github.io/cedar/" title="Esri Cedar github page">Cedar</a> integrates Vega with the GeoServices from ArcGIS. It adds templated documents for reusable charts that programatically bind to new data sources.</p>
           </div>
 
         </div>


### PR DESCRIPTION
We've developed a library that integrates Vega with GeoServices that are provided by ArcGIS Server. This is a common API used across [many government](http://catalog.data.gov/dataset?q=&sort=score+desc%2C+name+asc&res_format=Esri+REST&_res_format_limit=0) and [open data](http://opendata.arcgis.com/) services. 

Added to a link of integrations.
