### PR TITLE
quickfix of deadlink to vega-lite integrations

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
           <div class="header">
             <div class="lead">Vega-Lite's 3rd Party Integration</div>
             
-            <p><a href="https://vega.github.io/vega-lite/examples/applications.html">Check out the list of applications on the Vega-Lite website</a>
+            <p><a href="https://vega.github.io/vega-lite/usage/applications.html">Check out the list of applications on the Vega-Lite website.</a>
           </div>
 
         </div>


### PR DESCRIPTION
Current integration link on homepage links to an older version of a page, which no longer exists.
