### PR TITLE
Split the Docs & Tutorials links of Vega & Vega-lite

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                     </div>
                     <div class="desc">
                         <span class="lead">
-                            Vega
+                            <a href="https://vega.github.io/vega/">Vega</a>
                         </span>
                         is a visualization grammar, a declarative language for creating, saving, and sharing interactive visualization designs. With
                         Vega, you can describe the visual appearance and interactive behavior of a visualization in a JSON
@@ -81,7 +81,9 @@
                             <p>
                                 <a href="https://vega.github.io/vega/examples/">Examples</a>
                                 |
-                                <a href="https://vega.github.io/vega">Docs & Tutorials</a>
+                                <a href="https://vega.github.io/vega/docs/">Docs</a>
+                                |
+                                <a href="https://vega.github.io/vega/tutorials/">Tutorials</a>
                                 |
                                 <a href="https://vega.github.io/editor/#/custom/vega">Online Editor</a>
                                 |
@@ -101,7 +103,7 @@
                     </div>
                     <div class="desc">
                         <span class="lead">
-                            Vega-Lite
+                            <a href="https://vega.github.io/vega-lite">Vega-Lite</a>
                         </span>
                         is a high-level visualization grammar. It provides a concise JSON syntax for supporting rapid generation of visualizations
                         to support analysis. Vega-Lite support interactive multi-view graphics. Specifications can be compiled
@@ -110,7 +112,9 @@
                             <p>
                                 <a href="https://vega.github.io/vega-lite/examples/">Examples</a>
                                 |
-                                <a href="https://vega.github.io/vega-lite">Docs & Tutorials</a>
+                                <a href="https://vega.github.io/vega-lite/docs/">Docs</a>
+                                |
+                                <a href="https://vega.github.io/vega-lite/tutorials/getting_started.html">Tutorials</a>
                                 |
                                 <a href="https://vega.github.io/editor/#/custom/vega-lite">Online Editor</a>
                                 |


### PR DESCRIPTION
As mentioned in #20, I tried adding the Website links but they look cluttered. So I omitted this.

![Screenshot 2019-07-05 at 18 24 36](https://user-images.githubusercontent.com/13469652/60719836-ff3f8b80-9f52-11e9-85cc-df7d761b74e3.png)

Making the names clickable might be more appealing and make them consistent with other tools on the page. The image below is how it looks when Vega is hovered on  with this PR.

![Screenshot 2019-07-05 at 18 24 58](https://user-images.githubusercontent.com/13469652/60719844-036ba900-9f53-11e9-87a3-690f48c4a237.png)
