### PR TITLE
Remove datalib and mediawiki links

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,24 +277,9 @@
             <!-- VOYAGER AND COMPASSQL -->
 
             <div class="header">
-                <div class="lead">Utilities</div>
-                <p class="desc">
-                    <a href="http://vega.github.io/datalib/">Datalib</a> is a JavaScript data utility library. It provides facilities for data loading, type inference,
-                    common statistics, and string templates. This is a standalone library useful for data-driven JavaScript
-                    applications on both the client (web browser) and server (e.g., node.js).
-                </p>
-            </div>
-
-            <div class="header">
                 <div class="lead">
                     Vega's 3rd Party Integration
                 </div>
-            </div>
-
-            <div class="paper project">
-                <p>The MediaWiki
-                    <a href="https://www.mediawiki.org/wiki/Extension:Graph/Demo">Graph extension</a> allows you to embed Vega visualizations on MediaWiki sites, including Wikipedia.
-                </p>
             </div>
 
             <div class="header">


### PR DESCRIPTION
Datalib is outdated and the media wiki integration isn't that noteworthy anymore to highlight here.