### PR TITLE
Revert "shorter donation url"

### DIFF
--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -97,7 +97,7 @@
                             <li>Logo on vega.github.io — <em>visibility in the ecosystem</em></li>
                             <li>Social media recognition — <em>public support of open source</em></li>
                         </ul>
-                        <a href="https://numfocus.org/donate-to-vega">Sponsor directly</a><br/>
+                        <a href="https://payments-na1.hubspot.com/payments/purchase/hscs_SiOUq2jd9Mfpev7L5KS3cpnqMipuoUasVIyXxX5C3k0f5oedxDjSygnKEJW6D8Zd?referrer=SPONSOR">Sponsor directly</a><br/>
                         <a href="mailto:domoritz@cmu.edu?subject=Request Invoice & Support Letter for Vega Supporter&body=Hi Dominik%0D%0A%0D%0AWe would like to become a Vega supporter. Could you send us a support letter and invoice?%0D%0A%0D%0AThank you!">Request Invoice & Support Letter</a>
                     </div>
 


### PR DESCRIPTION
Reverts vega/vega.github.io#39

I just saw @domoritz and @mattijn messages on slack about the new link not rendering well in safari. It doesn't seem to work well in Firefox either, so maybe it is a good idea to stick with the old link since the page loads everywhere?